### PR TITLE
Bring the interpreted language closer to ASL

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
- (public_name aslinterp)
+ (public_name asli)
  (name main)
  (libraries aslinterp))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -19,16 +19,34 @@ let run_and_print = function
       Format.printf "@\n-------------------------\n\n@\n";
       Format.eprintf "@\n"
 
-let () =
-  let s =
-    stmt_from_list
+let cas =
+  ( stmt_from_list
       [
-        SAssign (LEVar "x", ELiteral (make_int 3));
-        SAssign (LEVar "y", ELiteral (make_int 5));
+        SAssign (LEVar "comparevalue", EGetArray (EVar "X", EVar "s"));
+        SAssign (LEVar "newvalue", EGetArray (EVar "X", EVar "t"));
+        SAssign (LEVar "address", EGetArray (EVar "X", EVar "n"));
+        SAssign (LEVar "oldvalue", EGetArray (EVar "Mem", EVar "address"));
         SCond
-          ( EBinop (EVar "x", Eq, EVar "y"),
-            SAssign (LEVar "r", EBinop (EVar "x", Plus, EVar "y")),
-            SAssign (LEVar "r", EBinop (EVar "x", Minus, EVar "y")) );
-      ]
-  in
-  run_and_print (s, C.empty)
+          ( EBinop (EVar "comparevalue", Eq, EVar "oldvalue"),
+            SAssign (LESetArray (LEVar "Mem", EVar "address"), EVar "newvalue"),
+            SPass );
+        SAssign (LESetArray (LEVar "X", EVar "s"), EVar "oldvalue");
+      ],
+    let address = Z.of_int 12345 in
+    let s = Z.of_int 1 in
+    let t = Z.of_int 2 in
+    let n = Z.of_int 3 in
+    let old_value = make_int 1 in
+    let compare_value = make_int 1 in
+    let new_value = make_int 2 in
+    let memory = VArray [ (address, old_value) ] in
+    let x = VArray [ (s, compare_value); (t, new_value); (n, VInt address) ] in
+    let c = C.empty in
+    let c = Result.get_ok @@ C.set "s" [] (VInt s) c in
+    let c = Result.get_ok @@ C.set "t" [] (VInt t) c in
+    let c = Result.get_ok @@ C.set "n" [] (VInt n) c in
+    let c = Result.get_ok @@ C.set "Mem" [] memory c in
+    let c = Result.get_ok @@ C.set "X" [] x c in
+    c )
+
+let () = run_and_print cas

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -6,82 +6,29 @@ open Aslinterp.Errors
 module C = SequentialContext
 module S = SequentialInterpretor
 
-let cas =
-  ( stmt_from_list
-      [
-        SAssign (LEVar "comparevalue", EMapAccess (EVar "X", EVar "s"));
-        SAssign (LEVar "newvalue", EMapAccess (EVar "X", EVar "t"));
-        SAssign (LEVar "address", EMapAccess (EVar "X", EVar "n"));
-        SAssign (LEVar "oldvalue", EMapAccess (EVar "Mem", EVar "address"));
-        SCond
-          ( EBinop (EVar "comparevalue", Eq, EVar "oldvalue"),
-            SAssign (LEMapWrite (LEVar "Mem", EVar "address"), EVar "newvalue"),
-            SPass );
-        SAssign (LEMapWrite (LEVar "X", EVar "s"), EVar "oldvalue");
-      ],
-    let address = Z.of_int 12345 in
-    let s = Z.of_int 1 in
-    let t = Z.of_int 2 in
-    let n = Z.of_int 3 in
-    let old_value = make_bitstring 3 8 in
-    let compare_value = make_bitstring 3 8 in
-    let new_value = make_bitstring 4 8 in
-    let memory = Map [ (IInt address, old_value) ] in
-    let x =
-      Map
-        [ (IInt s, compare_value); (IInt t, new_value); (IInt n, Int address) ]
-    in
-    let c = C.empty in
-    let c = Result.get_ok @@ C.set "s" [] (Int s) c in
-    let c = Result.get_ok @@ C.set "t" [] (Int t) c in
-    let c = Result.get_ok @@ C.set "n" [] (Int n) c in
-    let c = Result.get_ok @@ C.set "Mem" [] memory c in
-    let c = Result.get_ok @@ C.set "X" [] x c in
-    c )
-
 let run_and_print = function
   | s, c ->
       Format.printf "-------------------------@\n";
       pp_print_stmt Format.std_formatter s;
       Format.printf "@\n-------------------------@\n";
       (match S.eval_stmt c s with
-      | Ok c -> Format.printf "OK@\n"; C.pp_print Format.std_formatter c
+      | Ok c ->
+          Format.printf "OK@\n";
+          C.pp_print Format.std_formatter c
       | Error e -> pp_print_error Format.std_formatter e);
       Format.printf "@\n-------------------------\n\n@\n";
       Format.eprintf "@\n"
-
-let () = run_and_print cas
 
 let () =
   let s =
     stmt_from_list
       [
-        SAssign
-          ( LEVar "Matrix",
-            ELiteral
-              (make_array
-                 [
-                   make_array [ make_int 1; make_int 2; make_int 3 ];
-                   make_array [ make_int 4; make_int 5; make_int 6 ];
-                   make_array [ make_int 7; make_int 8; make_int 9 ];
-                 ]) );
-        SAssign (LEVar "zero", ELiteral (make_int 0));
-        SAssign (LEVar "one", ELiteral (make_int 1));
-        SAssign (LEVar "two", ELiteral (make_int 2));
-        SAssign (LEVar "three", ELiteral (make_int 3));
-        SAssign (LEVar "four", ELiteral (make_int 4));
-        SAssign
-          ( LEVar "x",
-            EMapAccess (EMapAccess (EVar "Matrix", EVar "one"), EVar "two") );
-        SAssign
-          ( LEMapWrite (LEMapWrite (LEVar "Matrix", EVar "zero"), EVar "zero"),
-            EVar "four" );
-        SAssign (LEVar "y", EVar "three");
-        SAssign (LEVar "r", EBinop (EVar "x", Plus, EVar "y"));
+        SAssign (LEVar "x", ELiteral (make_int 3));
+        SAssign (LEVar "y", ELiteral (make_int 5));
         SCond
           ( EBinop (EVar "x", Eq, EVar "y"),
-            SAssign (LEVar "r'", EBinop (EVar "x", Plus, ELiteral (make_int 5))),
-            SAssign (LEVar "r'", EBinop (EVar "x", Minus, EVar "y")) );
+            SAssign (LEVar "r", EBinop (EVar "x", Plus, EVar "y")),
+            SAssign (LEVar "r", EBinop (EVar "x", Minus, EVar "y")) );
       ]
   in
   run_and_print (s, C.empty)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -6,7 +6,7 @@ module type CONTEXT = sig
   type t
 
   val empty : t
-  val find : S.identifier -> t -> Values.value result
+  val find : S.identifier -> Values.value list -> t -> Values.value result
   val set : S.identifier -> Values.value list -> Values.value -> t -> t result
   val pp_print : Format.formatter -> t -> unit
 end
@@ -16,8 +16,10 @@ module SequentialContext : CONTEXT = struct
 
   let empty = S.IdMap.empty
 
-  let find x c =
-    S.IdMap.find_opt x c |> Option.to_result ~none:(UndefinedVariable x)
+  let find x addr c =
+    match S.IdMap.find_opt x c with
+    | None -> Error (UndefinedVariable x)
+    | Some v -> Values.find_in_value v addr
 
   let set x addr v c =
     match addr with

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -47,11 +47,20 @@ end
 module Logger (Ctx : CONTEXT) = struct
   include Ctx
 
-  let find x c =
-    Format.eprintf "Using %s@\n" x;
-    Ctx.find x c
+  let print_maybe_addr f = function
+    | x, [] -> Format.pp_print_string f x
+    | x, addr ->
+        Format.fprintf f "@[<2>%s@ [ %a ]@]" x
+          (Format.pp_print_list
+             ~pp_sep:(fun f () -> Format.fprintf f ",@ ")
+             Values.pp_print_value)
+          addr
+
+  let find x addr c =
+    Format.eprintf "Using   %a@\n" print_maybe_addr (x, addr);
+    Ctx.find x addr c
 
   let set x addr v c =
-    Format.eprintf "Setting %s@\n" x;
+    Format.eprintf "Setting %a@\n" print_maybe_addr (x, addr);
     Ctx.set x addr v c
 end

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -9,12 +9,10 @@ module type CONTEXT = sig
   val empty : t
   (** The empty context *)
 
-  val find :
-    Syntax.identifier -> Values.address -> t -> Values.value Errors.result
+  val find : Syntax.identifier -> t -> Values.value Errors.result
   (** Gives the value of a variable. *)
 
-  val set :
-    Syntax.identifier -> Values.address -> Values.value -> t -> t Errors.result
+  val set : Syntax.identifier -> Values.value -> t -> t Errors.result
   (** Binds the variable to its new value. *)
 
   val pp_print : Format.formatter -> t -> unit

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -9,7 +9,8 @@ module type CONTEXT = sig
   val empty : t
   (** The empty context *)
 
-  val find : Syntax.identifier -> t -> Values.value Errors.result
+  val find :
+    Syntax.identifier -> Values.value list -> t -> Values.value Errors.result
   (** Gives the value of a variable. *)
 
   val set :

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -12,7 +12,12 @@ module type CONTEXT = sig
   val find : Syntax.identifier -> t -> Values.value Errors.result
   (** Gives the value of a variable. *)
 
-  val set : Syntax.identifier -> Values.value -> t -> t Errors.result
+  val set :
+    Syntax.identifier ->
+    Values.value list ->
+    Values.value ->
+    t ->
+    t Errors.result
   (** Binds the variable to its new value. *)
 
   val pp_print : Format.formatter -> t -> unit

--- a/lib/errors.ml
+++ b/lib/errors.ml
@@ -1,6 +1,6 @@
 type error =
   | DivisionByZero
-  | TypeError of string * Values.value
+  | TypeError of string
   | UnsupportedOperation of string
   | SemanticError of string
   | UndefinedVariable of string
@@ -11,9 +11,7 @@ type error =
 let pp_print_error f e =
   match e with
   | DivisionByZero -> Format.pp_print_string f "Division by zero"
-  | TypeError (s, v) ->
-      Format.fprintf f "Type error: value %a is not of required type %s."
-        Values.pp_print_value v s
+  | TypeError s -> Format.fprintf f "Type error: %s" s
   | UnsupportedOperation s -> Format.fprintf f "Unsupported operation: %s" s
   | SemanticError s -> Format.fprintf f "Semantic error: %s" s
   | UndefinedVariable x -> Format.fprintf f "Variable %s is undefined." x

--- a/lib/errors.ml
+++ b/lib/errors.ml
@@ -1,5 +1,6 @@
 type error =
   | DivisionByZero
+  | TypeError of string * Values.value
   | UnsupportedOperation of string
   | SemanticError of string
   | UndefinedVariable of string
@@ -10,6 +11,9 @@ type error =
 let pp_print_error f e =
   match e with
   | DivisionByZero -> Format.pp_print_string f "Division by zero"
+  | TypeError (s, v) ->
+      Format.fprintf f "Type error: value %a is not of required type %s."
+        Values.pp_print_value v s
   | UnsupportedOperation s -> Format.fprintf f "Unsupported operation: %s" s
   | SemanticError s -> Format.fprintf f "Semantic error: %s" s
   | UndefinedVariable x -> Format.fprintf f "Variable %s is undefined." x

--- a/lib/errors.mli
+++ b/lib/errors.mli
@@ -1,5 +1,6 @@
 type error =
   | DivisionByZero
+  | TypeError of string * Values.value
   | UnsupportedOperation of string
   | SemanticError of string
   | UndefinedVariable of string

--- a/lib/errors.mli
+++ b/lib/errors.mli
@@ -1,6 +1,6 @@
 type error =
   | DivisionByZero
-  | TypeError of string * Values.value
+  | TypeError of string
   | UnsupportedOperation of string
   | SemanticError of string
   | UndefinedVariable of string

--- a/lib/sem.ml
+++ b/lib/sem.ml
@@ -8,8 +8,8 @@ open Errors
 let eval_binop v1 o v2 =
   match (v1, o, v2) with
   (* This should be working on all kinds of immutable values *)
-  | _, Eq, _ -> Ok (VBool (v1 == v2))
-  | _, NEq, _ -> Ok (VBool (v1 != v2))
+  | _, Eq, _ -> Ok (VBool (compare v1 v2 == 0))
+  | _, NEq, _ -> Ok (VBool (compare v1 v2 <> 0))
   (* Operations on Int *)
   | VInt x, LT, VInt y -> Ok (VBool (x < y))
   | VInt x, Leq, VInt y -> Ok (VBool (x <= y))

--- a/lib/sem.ml
+++ b/lib/sem.ml
@@ -109,7 +109,10 @@ module MakeInterpretor (Ctx : Context.CONTEXT) = struct
 
   let unpack_bool = function
     | VBool b -> Ok b
-    | v -> Error (TypeError ("bool", v))
+    | v ->
+        Error
+          (TypeError
+             (Format.asprintf "Value %a is not a boolean." pp_print_value v))
 
   let rec eval_expr c e =
     match e with

--- a/lib/sem.ml
+++ b/lib/sem.ml
@@ -7,65 +7,64 @@ open Errors
 
 let eval_binop v1 o v2 =
   match (v1, o, v2) with
-  | Bitstr s1, Eq, Bitstr s2 -> Ok (Bool (Array.for_all2 (==) s1 s2))
-  | Bitstr s1, NEq, Bitstr s2 -> Ok (Bool (Array.exists2 (!=) s1 s2))
-  | _, Eq, _ -> Ok (Bool (v1 == v2))
-  | _, NEq, _ ->
-      Ok (Bool (v1 != v2)) (* It should be working on all kinds of immutable values *)
+  (* This should be working on all kinds of immutable values *)
+  | _, Eq, _ -> Ok (VBool (v1 == v2))
+  | _, NEq, _ -> Ok (VBool (v1 != v2))
   (* Operations on Int *)
-  | Int x, LT, Int y -> Ok (Bool (x < y))
-  | Int x, Leq, Int y -> Ok (Bool (x <= y))
-  | Int x, GT, Int y -> Ok (Bool (x > y))
-  | Int x, Geq, Int y -> Ok (Bool (x >= y))
-  | Int x, Plus, Int y -> Ok (Int Z.(x + y))
-  | Int x, Minus, Int y -> Ok (Int Z.(x - y))
-  | Int x, Mult, Int y -> Ok (Int Z.(x * y))
-  | Int _, DIV, Int y when y = Z.zero -> Error DivisionByZero
-  | Int x, DIV, Int y -> Ok (Int Z.(x / y))
-  | Int _, MOD, Int y when y = Z.zero -> Error DivisionByZero
-  | Int x, MOD, Int y -> Ok (Int Z.(x mod y))
-  | Int x, RSh, Int y -> Ok (Int Z.(x asr to_int y))
-  | Int x, LSh, Int y -> Ok (Int Z.(x lsl to_int y))
-  | Int x, Pow, Int y -> Ok (Int Z.(x ** to_int y))
+  | VInt x, LT, VInt y -> Ok (VBool (x < y))
+  | VInt x, Leq, VInt y -> Ok (VBool (x <= y))
+  | VInt x, GT, VInt y -> Ok (VBool (x > y))
+  | VInt x, Geq, VInt y -> Ok (VBool (x >= y))
+  | VInt x, Plus, VInt y -> Ok (VInt Z.(x + y))
+  | VInt x, Minus, VInt y -> Ok (VInt Z.(x - y))
+  | VInt x, Mult, VInt y -> Ok (VInt Z.(x * y))
+  | VInt _, DIV, VInt y when y = Z.zero -> Error DivisionByZero
+  | VInt x, DIV, VInt y -> Ok (VInt Z.(x / y))
+  | VInt _, MOD, VInt y when y = Z.zero -> Error DivisionByZero
+  | VInt x, MOD, VInt y -> Ok (VInt Z.(x mod y))
+  | VInt x, RSh, VInt y -> Ok (VInt Z.(x asr to_int y))
+  | VInt x, LSh, VInt y -> Ok (VInt Z.(x lsl to_int y))
+  | VInt x, Pow, VInt y -> Ok (VInt Z.(x ** to_int y))
   (* Operations on Real *)
-  | Real x, LT, Real y -> Ok (Bool (x < y))
-  | Real x, Leq, Real y -> Ok (Bool (x <= y))
-  | Real x, GT, Real y -> Ok (Bool (x > y))
-  | Real x, Geq, Real y -> Ok (Bool (x >= y))
-  | Real x, Plus, Real y -> Ok (Real Q.(x + y))
-  | Real x, Minus, Real y -> Ok (Real Q.(x - y))
-  | Real x, Mult, Real y -> Ok (Real Q.(x * y))
-  | Real _, RDiv, Real y when y = Q.zero -> Error DivisionByZero
-  | Real x, RDiv, Real y -> Ok (Real Q.(x / y))
-  | Real x, Pow, Int y -> Ok (Real (Q.of_float (Q.to_float x ** Z.to_float y)))
+  | VReal x, LT, VReal y -> Ok (VBool (x < y))
+  | VReal x, Leq, VReal y -> Ok (VBool (x <= y))
+  | VReal x, GT, VReal y -> Ok (VBool (x > y))
+  | VReal x, Geq, VReal y -> Ok (VBool (x >= y))
+  | VReal x, Plus, VReal y -> Ok (VReal Q.(x + y))
+  | VReal x, Minus, VReal y -> Ok (VReal Q.(x - y))
+  | VReal x, Mult, VReal y -> Ok (VReal Q.(x * y))
+  | VReal _, RDiv, VReal y when y = Q.zero -> Error DivisionByZero
+  | VReal x, RDiv, VReal y -> Ok (VReal Q.(x / y))
+  | VReal x, Pow, VInt y ->
+      Ok (VReal (Q.of_float (Q.to_float x ** Z.to_float y)))
   (* Operations on boolean *)
-  | Bool a, BAnd, Bool b -> Ok (Bool (a && b))
-  | Bool a, BOr, Bool b -> Ok (Bool (a || b))
-  | Bool a, BEq, Bool b -> Ok (Bool (a == b))
-  | Bool a, BImpl, Bool b -> Ok (Bool ((not a) || b))
-  (* Operations on bitstrings *)
+  | VBool a, BAnd, VBool b -> Ok (VBool (a && b))
+  | VBool a, BOr, VBool b -> Ok (VBool (a || b))
+  | VBool a, BEq, VBool b -> Ok (VBool (a == b))
+  | VBool a, BImpl, VBool b -> Ok (VBool ((not a) || b))
+  (* Operations on bitvectors *)
   (* Here we assume that length s1 == length s2 *)
-  | Bitstr s1, EOR, Bitstr s2 -> Ok (Bitstr (Array.map2 ( != ) s1 s2))
-  | Bitstr s1, And, Bitstr s2 -> Ok (Bitstr (Array.map2 ( && ) s1 s2))
-  | Bitstr s1, Or, Bitstr s2 -> Ok (Bitstr (Array.map2 ( || ) s1 s2))
-  | Bitstr s1, Plus, Bitstr s2 ->
-      let i1 = z_of_bitstring s1 in
-      let i2 = z_of_bitstring s2 in
-      let s3 = bitstring_of_z (Z.add i1 i2) (Array.length s1) in
-      Ok (Bitstr s3)
-  | Bitstr s1, Minus, Bitstr s2 ->
-      let i1 = z_of_bitstring s1 in
-      let i2 = z_of_bitstring s2 in
-      let s3 = bitstring_of_z (Z.sub i1 i2) (Array.length s1) in
-      Ok (Bitstr s3)
-  | Bitstr s1, Plus, Int i2 ->
-      let i1 = z_of_bitstring s1 in
-      let s3 = bitstring_of_z (Z.add i1 i2) (Array.length s1) in
-      Ok (Bitstr s3)
-  | Bitstr s1, Minus, Int i2 ->
-      let i1 = z_of_bitstring s1 in
-      let s3 = bitstring_of_z (Z.sub i1 i2) (Array.length s1) in
-      Ok (Bitstr s3)
+  | VBitVec s1, EOR, VBitVec s2 -> Ok (VBitVec (List.map2 ( != ) s1 s2))
+  | VBitVec s1, And, VBitVec s2 -> Ok (VBitVec (List.map2 ( && ) s1 s2))
+  | VBitVec s1, Or, VBitVec s2 -> Ok (VBitVec (List.map2 ( || ) s1 s2))
+  | VBitVec s1, Plus, VBitVec s2 ->
+      let i1 = z_of_bitvector s1 in
+      let i2 = z_of_bitvector s2 in
+      let s3 = bitvector_of_z (Z.add i1 i2) (List.length s1) in
+      Ok (VBitVec s3)
+  | VBitVec s1, Minus, VBitVec s2 ->
+      let i1 = z_of_bitvector s1 in
+      let i2 = z_of_bitvector s2 in
+      let s3 = bitvector_of_z (Z.sub i1 i2) (List.length s1) in
+      Ok (VBitVec s3)
+  | VBitVec s1, Plus, VInt i2 ->
+      let i1 = z_of_bitvector s1 in
+      let s3 = bitvector_of_z (Z.add i1 i2) (List.length s1) in
+      Ok (VBitVec s3)
+  | VBitVec s1, Minus, VInt i2 ->
+      let i1 = z_of_bitvector s1 in
+      let s3 = bitvector_of_z (Z.sub i1 i2) (List.length s1) in
+      Ok (VBitVec s3)
   | _ ->
       Error
         (UnsupportedOperation
@@ -74,10 +73,10 @@ let eval_binop v1 o v2 =
 
 let eval_unop o v =
   match (o, v) with
-  | UBNeg, Bool b -> Ok (Bool (not b))
-  | UNot, Bitstr s -> Ok (Bitstr (Array.map not s))
-  | UMinus, Int x -> Ok (Int (Z.neg x))
-  | UMinus, Real x -> Ok (Real (Q.neg x))
+  | UBNeg, VBool b -> Ok (VBool (not b))
+  | UNot, VBitVec s -> Ok (VBitVec (List.map not s))
+  | UMinus, VInt x -> Ok (VInt (Z.neg x))
+  | UMinus, VReal x -> Ok (VReal (Q.neg x))
   | _ ->
       Error
         (UnsupportedOperation
@@ -90,9 +89,6 @@ let eval_unop o v =
 module type INTERPRETOR = sig
   type context
 
-  val do_one_step_expr :
-    context -> Syntax.expr -> (context * Syntax.expr) Errors.result
-
   val eval_expr :
     context -> Syntax.expr -> (context * Values.value) Errors.result
 
@@ -102,16 +98,7 @@ module type INTERPRETOR = sig
   val eval_stmt : context -> Syntax.stmt -> context Errors.result
 end
 
-module type SEMANTIC_DESCRIPTOR = sig
-  val semi_column_concurrent : bool
-end
-
-module SequentialSemantics = struct
-  let semi_column_concurrent = false
-end
-
-module MakeInterpretor (Ctx : Context.CONTEXT) (SD : SEMANTIC_DESCRIPTOR) =
-struct
+module MakeInterpretor (Ctx : Context.CONTEXT) = struct
   (********************************************************************************************)
   (* Expressions *)
   type context = Ctx.t
@@ -120,114 +107,30 @@ struct
 
   let ( let* ) = Result.bind
 
-  let rec is_map_literal = function
-    | EVar _ -> true
-    | EMapAccess (e1, ELiteral _) -> is_map_literal e1
-    | _ -> false
-
-  let rec exp_to_little_endian = function
-    | EVar x -> Ok (x, [])
-    | EMapAccess (e1, ELiteral vi) ->
-        let* i = value_to_index vi in
-        let* x, rev_addr_e1 = exp_to_little_endian e1 in
-        Ok (x, i :: rev_addr_e1)
-    | _ ->
-        Error
-          (InterpretorError
-             "Cannot transform expr into address: Not fully reduced.")
-
-  let exp_to_big_endian e =
-    let* x, rev_addr = exp_to_little_endian e in
-    Ok (x, List.rev rev_addr)
-
-  let rec do_one_step_expr c e =
+  let rec eval_expr c e =
     match e with
+    | ELiteral v -> Ok (c, v)
     (* Rule Extract-Context  *)
     | EVar x ->
-        let* v = Ctx.find x [] c in
-        Ok (c, ELiteral v)
+        let* v = Ctx.find x c in
+        Ok (c, v)
     (* Rule Reduce-Unop *)
-    | EUnop (o, ELiteral v) ->
-        let* v' = eval_unop o v in
-        Ok (c, ELiteral v')
-    (* Rule Reduce-Binop *)
-    | EBinop (ELiteral v1, o, ELiteral v2) ->
-        let* v = eval_binop v1 o v2 in
-        Ok (c, ELiteral v)
-    (* Rule Reduce-Map-Access *)
-    | _ when is_map_literal e ->
-        let* x, addr = exp_to_big_endian e in
-        let* v' = Ctx.find x addr c in
-        Ok (c, ELiteral v')
-    (* Rule Reduce-Map-Access-Literal *)
-    | EMapAccess (ELiteral va, ELiteral vi) ->
-        let* i = value_to_index vi in
-        let* v' = find_address_in_value va [ i ] in
-        Ok (c, ELiteral v')
-    (*******************)
-    (* Rule Progress-Unop *)
     | EUnop (o, e') ->
-        let* c, e'' = do_one_step_expr c e' in
-        Ok (c, EUnop (o, e''))
-    (* Rule Progress-Binop-Right *)
-    | EBinop (e1, o, e2) when not (is_literal e2) ->
-        let* c, e2' = do_one_step_expr c e2 in
-        Ok (c, EBinop (e1, o, e2'))
-    (* Rule Progress-Binop-Left *)
-    | EBinop (e1, o, e2) when not (is_literal e1) ->
-        let* c, e1' = do_one_step_expr c e1 in
-        Ok (c, EBinop (e1', o, e2))
-    (* Rule Progress-Map-Access-left *)
-    | EMapAccess (e1, e2) when (not (is_map_literal e1)) && not (is_literal e1)
-      ->
-        let* c, e1' = do_one_step_expr c e1 in
-        Ok (c, EMapAccess (e1', e2))
-    (* Rule Progress-Map-Access-Right *)
-    | EMapAccess (e1, e2) when not (is_literal e2) ->
-        let* c, e2' = do_one_step_expr c e2 in
-        Ok (c, EMapAccess (e1, e2'))
-    (* Final match to guard everything.
-       Should not happen, but otherwise this does not compile. *)
-    | _ -> Error BlockedInterpretor
-
-  let rec eval_expr c e =
-    match do_one_step_expr c e with
-    | Ok (c', ELiteral v) -> Ok (c', v)
-    | Ok (c', e') -> eval_expr c' e'
-    | Error err -> Error err
+        let* c', v = eval_expr c e' in
+        let* v' = eval_unop o v in
+        Ok (c', v')
+    (* Rule Reduce-Binop *)
+    | EBinop (e1, o, e2) ->
+        let* c1, v1 = eval_expr c e1 in
+        let* c2, v2 = eval_expr c1 e2 in
+        let* v = eval_binop v1 o v2 in
+        Ok (c2, v)
 
   (********************************************************************************************)
   (* Statements *)
-
-  let rec is_lexpr_literal = function
-    | LEVar _ -> true
-    | LEMapWrite (le, e) -> is_literal e && is_lexpr_literal le
-
-  let rec do_one_step_lexpr c le =
-    match le with
-    | LEMapWrite (le, e) when not (is_literal e) ->
-        let* c', e' = do_one_step_expr c e in
-        Ok (c', LEMapWrite (le, e'))
-    | LEMapWrite (le, e) when not (is_lexpr_literal le) ->
-        let* c', le' = do_one_step_lexpr c le in
-        Ok (c', LEMapWrite (le', e))
-    | _ -> Error BlockedInterpretor
-
-  let rec lexpr_to_little_endian = function
-    | LEVar x -> Ok (x, [])
-    | LEMapWrite (le, ELiteral vi) ->
-        let* i = value_to_index vi in
-        let* x, rev_addr_le = lexpr_to_little_endian le in
-        Ok (x, i :: rev_addr_le)
-    | LEMapWrite (_, _) ->
-        Error
-          (InterpretorError
-             "Cannot convert left-hand expression to address: not fully \
-              reduced.")
-
-  let lexpr_to_big_endian le =
-    let* x, rev_addr = lexpr_to_little_endian le in
-    Ok (x, List.rev rev_addr)
+  let unpack_bool = function
+    | VBool b -> Ok b
+    | v -> Error (TypeError ("bool", v))
 
   let rec do_one_step_stmt c s =
     match s with
@@ -235,30 +138,19 @@ struct
     | SThen (SPass, s2) -> Ok (c, s2)
     (* Rule Progress-Then-Left *)
     | SThen (s1, s2) ->
-        if SD.semi_column_concurrent then raise (Failure "Not yet implemented")
-        else
-          let* c', s1' = do_one_step_stmt c s1 in
-          Ok (c', SThen (s1', s2))
+        let* c', s1' = do_one_step_stmt c s1 in
+        Ok (c', SThen (s1', s2))
     (* Rule Reduce-Map-Write *)
-    | SAssign (le, ELiteral v2) when is_lexpr_literal le ->
-        let* x, addr = lexpr_to_big_endian le in
-        let* c' = Ctx.set x addr v2 c in
-        Ok (c', SPass)
-    (* Rule Progress-Assign-Right *)
-    | SAssign (le, e) when not (is_literal e) ->
-        let* c', e' = do_one_step_expr c e in
-        Ok (c', SAssign (le, e'))
-    (* Rule Progress-Assign-Left *)
-    | SAssign (le, e) when not (is_lexpr_literal le) ->
-        let* c', le' = do_one_step_lexpr c le in
-        Ok (c', SAssign (le', e))
+    | SAssign (LEVar x, e) ->
+        let* c', v = eval_expr c e in
+        let* c'' = Ctx.set x v c' in
+        Ok (c'', SPass)
     (* Rule Reduce-Cond *)
-    | SCond (ELiteral (Bool b), s1, s2) -> Ok (c, if b then s1 else s2)
-    (* Rule Progress-Cond *)
     | SCond (e, s1, s2) ->
-        let* c', e' = do_one_step_expr c e in
-        Ok (c', SCond (e', s1, s2))
-    | _ -> Error BlockedInterpretor
+        let* c', v = eval_expr c e in
+        let* b = unpack_bool v in
+        Ok (c', if b then s1 else s2)
+    | SPass -> Error BlockedInterpretor
 
   let rec eval_stmt c s =
     match do_one_step_stmt c s with
@@ -268,5 +160,4 @@ struct
 end
 
 module SequentialInterpretor =
-  MakeInterpretor
-    (Context.Logger (Context.SequentialContext)) (SequentialSemantics)
+  MakeInterpretor (Context.Logger (Context.SequentialContext))

--- a/lib/sem.ml
+++ b/lib/sem.ml
@@ -137,6 +137,11 @@ module MakeInterpretor (Ctx : Context.CONTEXT) = struct
         let* b = unpack_bool v' in
         let* c'', v'' = eval_expr c' (if b then e2 else e3) in
         Ok (c'', v'')
+    | EGetArray (e1, e2) ->
+        let* c', v2 = eval_expr c e2 in
+        let* c'', v1 = eval_expr c' e1 in
+        let* v = find_in_value v1 [ v2 ] in
+        Ok (c'', v)
 
   (********************************************************************************************)
   (* Statements *)

--- a/lib/sem.mli
+++ b/lib/sem.mli
@@ -14,16 +14,9 @@ module type INTERPRETOR = sig
   type context
 
   (** {3 Semantics of expressions } *)
-
-  val do_one_step_expr :
-    context -> Syntax.expr -> (context * Syntax.expr) Errors.result
-  (** A small-step transition function, that we try to keep as close as possible to the
-    semantic rules. *)
-
   val eval_expr :
     context -> Syntax.expr -> (context * Values.value) Errors.result
-  (** A evaluation function for expressions, that uses the function [do_one_step_expr] and take
-    its transitive closure. *)
+  (** Evaluates an expression inside a context. *)
 
   (** {3 Semantics of statements }
 
@@ -35,7 +28,7 @@ module type INTERPRETOR = sig
     statements.
 
     We try to keep as close as possible to the
-    semantic rules. It uses [do_one_step_expr] for the reduction of expressions, as
+    semantic rules. It uses [eval_expr] for the reduction of expressions, as
     specified by the semantic rules. *)
 
   val eval_stmt : context -> Syntax.stmt -> context Errors.result
@@ -43,13 +36,7 @@ module type INTERPRETOR = sig
     [do_one_step_stmt] transition function. *)
 end
 
-module type SEMANTIC_DESCRIPTOR = sig
-  val semi_column_concurrent : bool
-end
-
-module SequentialSemantics : SEMANTIC_DESCRIPTOR
-
-module MakeInterpretor (Ctx : Context.CONTEXT) (_ : SEMANTIC_DESCRIPTOR) :
+module MakeInterpretor (Ctx : Context.CONTEXT) :
   INTERPRETOR with type context = Ctx.t
 
 (** {Interpretors} *)

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -34,6 +34,7 @@ type expr =
   | EVar of identifier  (** A variable *)
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
+  | ECond of expr * expr * expr  (** [if e1 then e2 else e3] *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)
@@ -125,6 +126,9 @@ let rec pp_print_expr f e =
         pp_print_expr e2
   | EVar x -> pp_print_string f x
   | ELiteral v -> Values.pp_print_value f v
+  | ECond (e1, e2, e3) ->
+      fprintf f "@[<3>@[<h>if@ %a@ then@]@ %a@ else@ %a@]" pp_print_expr e1
+        pp_print_expr e2 pp_print_expr e3
 
 and pp_print_lexpr f e = match e with LEVar x -> pp_print_string f x
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -35,6 +35,7 @@ type expr =
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
   | ECond of expr * expr * expr  (** [if e1 then e2 else e3] *)
+  | EGetArray of expr * expr  (** [e1[e2]], but only for arrays *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)
@@ -129,6 +130,8 @@ let rec pp_print_expr f e =
   | ECond (e1, e2, e3) ->
       fprintf f "@[<3>@[<h>if@ %a@ then@]@ %a@ else@ %a@]" pp_print_expr e1
         pp_print_expr e2 pp_print_expr e3
+  | EGetArray (e1, e2) ->
+      fprintf f "@[<2>%a[@,%a@;<0 -2>]@]" pp_print_expr e1 pp_print_expr e2
 
 and pp_print_lexpr f e = match e with LEVar x -> pp_print_string f x
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -34,7 +34,6 @@ type expr =
   | EVar of identifier  (** A variable *)
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
-  | EMapAccess of expr * expr  (** e1[e2] *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)
@@ -50,7 +49,7 @@ type expr =
    | EStruct of (string * expr) list
 *)
 
-and lexpr = LEVar of identifier | LEMapWrite of lexpr * expr
+and lexpr = LEVar of identifier
 (* Unsupported now:
    | LEVars of lexpr
    | LEField of lexpr * identifier
@@ -78,7 +77,6 @@ and stmt =
    | STry
    | SPragma
 *)
-and subpgm = string list * stmt
 
 let stmt_from_list = function
   | [] -> SPass
@@ -127,14 +125,8 @@ let rec pp_print_expr f e =
         pp_print_expr e2
   | EVar x -> pp_print_string f x
   | ELiteral v -> Values.pp_print_value f v
-  | EMapAccess (e1, e2) ->
-      fprintf f "@[<2>%a[@,%a@;<0 -2>]@]" pp_print_expr e1 pp_print_expr e2
 
-and pp_print_lexpr f e =
-  match e with
-  | LEVar x -> pp_print_string f x
-  | LEMapWrite (le, e) ->
-      fprintf f "@[<2>%a[@,%a@;<0 -2>]@]" pp_print_lexpr le pp_print_expr e
+and pp_print_lexpr f e = match e with LEVar x -> pp_print_string f x
 
 and pp_print_stmt f s =
   match s with
@@ -146,9 +138,3 @@ and pp_print_stmt f s =
   | SCond (e, s1, s2) ->
       fprintf f "@[<3>@[<h>if@ %a@ then@]@ %a@ else@ %a@]" pp_print_expr e
         pp_print_stmt s1 pp_print_stmt s2
-
-and pp_print_subpgm f = function
-  | args, s ->
-      fprintf f "@[<hov 3>@[<hv 2>fun %a@]@ => %a@]"
-        (pp_print_list ~pp_sep:pp_print_space pp_print_string)
-        args pp_print_stmt s

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -51,7 +51,7 @@ type expr =
    | EStruct of (string * expr) list
 *)
 
-and lexpr = LEVar of identifier
+and lexpr = LEVar of identifier | LESetArray of lexpr * expr
 (* Unsupported now:
    | LEVars of lexpr
    | LEField of lexpr * identifier
@@ -133,7 +133,11 @@ let rec pp_print_expr f e =
   | EGetArray (e1, e2) ->
       fprintf f "@[<2>%a[@,%a@;<0 -2>]@]" pp_print_expr e1 pp_print_expr e2
 
-and pp_print_lexpr f e = match e with LEVar x -> pp_print_string f x
+and pp_print_lexpr f e =
+  match e with
+  | LEVar x -> pp_print_string f x
+  | LESetArray (le, e) ->
+      fprintf f "@[<2>%a[@,%a@;<0 -2>]@]" pp_print_lexpr le pp_print_expr e
 
 and pp_print_stmt f s =
   match s with

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -55,7 +55,6 @@ type expr =
   | EVar of identifier  (** A variable *)
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
-  | EMapAccess of expr * expr  (** e1[e2] *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)
@@ -73,7 +72,7 @@ type expr =
 
 (** {3 Statements} *)
 
-and lexpr = LEVar of identifier | LEMapWrite of lexpr * expr
+and lexpr = LEVar of identifier
 (* Unsupported now:
    | LEVars of lexpr
    | LEField of lexpr * identifier
@@ -101,14 +100,6 @@ and stmt =
    | SPragma
 *)
 
-(** {3 Subprograms} *)
-
-(** The type subpgm is the type of functions created in ASL. *)
-and subpgm = string list * stmt
-(** In ASL, functions and subprograms have the same external context as the other statements.
-   However, during interpretation, a subprogram builds a context, which are the local
-   variables that it has created. *)
-
 (** {2 Utilities} *)
 
 val stmt_from_list : stmt list -> stmt
@@ -124,4 +115,3 @@ val pp_print_binop : Format.formatter -> binop -> unit
 val pp_print_expr : Format.formatter -> expr -> unit
 val pp_print_lexpr : Format.formatter -> lexpr -> unit
 val pp_print_stmt : Format.formatter -> stmt -> unit
-val pp_print_subpgm : Format.formatter -> subpgm -> unit

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -55,6 +55,7 @@ type expr =
   | EVar of identifier  (** A variable *)
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
+  | ECond of expr * expr * expr  (** [if e1 then e2 else e3] *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -74,7 +74,7 @@ type expr =
 
 (** {3 Statements} *)
 
-and lexpr = LEVar of identifier
+and lexpr = LEVar of identifier | LESetArray of lexpr * expr
 (* Unsupported now:
    | LEVars of lexpr
    | LEField of lexpr * identifier

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -56,6 +56,7 @@ type expr =
   | EUnop of unop * expr  (** [- e] *)
   | EBinop of expr * binop * expr  (** [e1 + e2] *)
   | ECond of expr * expr * expr  (** [if e1 then e2 else e3] *)
+  | EGetArray of expr * expr  (** [e1[e2]], but only for arrays *)
 (* Unsupported now:
    | EUnknown (** [UNKNWON] *)
    | EUnstable (** [UNSTABLE] *)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1,110 +1,68 @@
-type bitstring = bool array
-type index = IInt of Z.t | IString of string
-type address = index list
-type 'a map = (index * 'a) list
+type bitvector = bool list
 
+(** Values in CoreASL, ie values from ASL, where compound values are mapped to Map. *)
 type value =
-  | Bitstr of bitstring
-  | Int of Z.t
-  | Real of Q.t
-  | Bool of bool
-  | String of string
-  | Map of value map
+  | VBitVec of bitvector  (** Bit strings of fixed size *)
+  | VInt of Z.t  (** Integers, unbounded in size, signed *)
+  | VReal of Q.t
+      (** Real number in the mathematical sense, unbounded in size or precision *)
+  | VBool of bool  (** Boolean *)
+  | VString of string  (** Strings *)
+  | VEnum of string  (** Enums *)
+  | VTuple of tuple  (** Tuples **)
+  | VRecord of record  (** Record types *)
+  | VArray of varray  (** Array *)
+
+and record = (string * value) list
+and varray = (Z.t * value) list
+and tuple = value list
 
 module F = Format
 
 let pp_print_bit f b = F.pp_print_int f (if b then 1 else 0)
-
-let pp_print_index f i =
-  match i with
-  | IInt z -> Z.pp_print f z
-  | IString s -> F.fprintf f "@[<h>'%s'@]" s
-
 let list_separator f () = F.fprintf f ",@ "
 
-let rec pp_print_map_element f = function
-  | i, v -> F.fprintf f "@[<h>%a:@ %a@]" pp_print_index i pp_print_value v
+let rec pp_print_array_element f = function
+  | i, v -> F.fprintf f "@[<h>%a:@ %a@]" Z.pp_print i pp_print_value v
+
+and pp_print_record_element f = function
+  | s, v -> F.fprintf f "@[<h>'%s':@ %a@]" s pp_print_value v
 
 and pp_print_value f v =
   match v with
-  | Real x -> Q.pp_print f x
-  | Int x -> Z.pp_print f x
-  | Bool b -> F.pp_print_bool f b
-  | String s -> F.fprintf f "@[<h>\"%s\"@]" s
-  | Bitstr a ->
+  | VReal x -> Q.pp_print f x
+  | VInt x -> Z.pp_print f x
+  | VBool b -> F.pp_print_bool f b
+  | VString s -> F.fprintf f "@[<h>\"%s\"@]" s
+  | VBitVec l ->
       F.fprintf f "@[<h>b\"%a\"@]"
-        (F.pp_print_seq ~pp_sep:F.pp_print_cut pp_print_bit)
-        (Array.to_seq a)
-  | Map l ->
+        (F.pp_print_list ~pp_sep:F.pp_print_cut pp_print_bit)
+        l
+  | VEnum s -> F.pp_print_string f s
+  | VTuple l ->
+      F.fprintf f "@[<hv 2>( %a )@]"
+        (F.pp_print_list ~pp_sep:list_separator pp_print_value)
+        l
+  | VRecord l ->
+      F.fprintf f "@[<hv 2>{ %a }@]"
+        (F.pp_print_list ~pp_sep:list_separator pp_print_record_element)
+        l
+  | VArray l ->
       F.fprintf f "@[<hv 2>[ %a ]@]"
-        (F.pp_print_list ~pp_sep:list_separator pp_print_map_element)
+        (F.pp_print_list ~pp_sep:list_separator pp_print_array_element)
         l
 
-let pp_print_address = F.pp_print_list ~pp_sep:list_separator pp_print_index
-
-let bitstring_of_z n l =
+let bitvector_of_z n l =
   let add_trailing_zeros s = Seq.append s (Seq.repeat false) in
   let unfolder n =
     if n == Z.zero then None else Some Z.(n mod ~$2 == one, n / ~$2)
   in
-  Seq.unfold unfolder n |> add_trailing_zeros |> Seq.take l |> Array.of_seq
+  Seq.unfold unfolder n |> add_trailing_zeros |> Seq.take l |> List.of_seq
 
-let z_of_bitstring s =
+let z_of_bitvector s =
   let folder n i b = if b then Z.(n + (one lsl i)) else n in
-  Seq.fold_lefti folder Z.zero (Array.to_seq s)
+  Seq.fold_lefti folder Z.zero (List.to_seq s)
 
-let make_int x = Int (Z.of_int x)
-let make_real x = Real (Q.of_float x)
-let make_bitstring x l = Bitstr (bitstring_of_z (Z.of_int x) l)
-let make_array l = Map (List.mapi (fun i x -> (IInt (Z.of_int i), x)) l)
-
-module Addresses = struct
-  let ( let* ) = Result.bind
-
-  open Errors
-  open List
-
-  let rec find_address_in_value v addr =
-    match (v, addr) with
-    | _, [] -> Ok v
-    | Map a, h :: t when mem_assoc h a -> find_address_in_value (assoc h a) t
-    | Map a, h :: _t ->
-        Error
-          (IndexOutOfBounds
-             (Format.asprintf "%a in %a" pp_print_index h pp_print_value (Map a)))
-    | _, _h :: _t ->
-        Error
-          (UnsupportedOperation
-             (Format.asprintf "Cannot index %a." pp_print_value v))
-
-  let rec set_address_in_value v addr new_value =
-    match (v, addr) with
-    | _, [] ->
-        Error
-          (InterpretorError "Problem setting value. This should not happen.")
-    | Map a, h :: [] -> Ok (Map ((h, new_value) :: remove_assoc h a))
-    | Map a, h :: t when mem_assoc h a ->
-        let* v' = set_address_in_value (assoc h a) t new_value in
-        Ok (Map ((h, v') :: remove_assoc h a))
-    | Map a, h :: _t ->
-        Error
-          (IndexOutOfBounds
-             (Format.asprintf "%a in %a" pp_print_index h pp_print_value (Map a)))
-    | _, _h :: _t ->
-        Error
-          (UnsupportedOperation
-             (Format.asprintf "Cannot index %a." pp_print_value v))
-
-  let value_to_index v =
-    match v with
-    | Int z -> Ok (IInt z)
-    | String s -> Ok (IString s)
-    | _ ->
-        Error
-          (UnsupportedOperation
-             (Format.asprintf "Cannot index by value %a." pp_print_value v))
-end
-
-let find_address_in_value = Addresses.find_address_in_value
-let set_address_in_value = Addresses.set_address_in_value
-let value_to_index = Addresses.value_to_index
+let make_int x = VInt (Z.of_int x)
+let make_real x = VReal (Q.of_float x)
+let make_bitvector x l = VBitVec (bitvector_of_z (Z.of_int x) l)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -66,3 +66,22 @@ let z_of_bitvector s =
 let make_int x = VInt (Z.of_int x)
 let make_real x = VReal (Q.of_float x)
 let make_bitvector x l = VBitVec (bitvector_of_z (Z.of_int x) l)
+
+let rec find_in_value v addr =
+  let open Errors in
+  match (v, addr) with
+  | _, [] -> Ok v
+  | VRecord l, VString s :: t when List.mem_assoc s l ->
+      find_in_value (List.assoc s l) t
+  | VArray l, VInt i :: t when List.mem_assoc i l ->
+      find_in_value (List.assoc i l) t
+  | VArray _, VInt i :: _ ->
+      Error
+        (IndexOutOfBounds
+           (Format.asprintf "Index %a is not defined for %a" pp_print_value
+              (VInt i) pp_print_value v))
+  | _, t :: _ ->
+      Error
+        (UnsupportedOperation
+           (Format.asprintf "Indexing %a with %a." pp_print_value v
+              pp_print_value t))

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -24,3 +24,4 @@ val make_int : int -> value
 val make_real : float -> value
 val make_bitvector : int -> int -> value
 val find_in_value : value -> value list -> value Errors.result
+val set_in_value : value -> value list -> value -> value Errors.result

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -1,39 +1,25 @@
-type bitstring = bool array
-
-(** Type of indexing values, either in ASL tuples, ASL arrays or ASL structures. *)
-type index = IInt of Z.t | IString of string
-
-type address = index list
-(** Type of nested indexing values for Map cases. *)
-
-type 'a map = (index * 'a) list
-(** Underlying object behind a Map. It is for now an association list. *)
+type bitvector = bool list
 
 (** Values in CoreASL, ie values from ASL, where compound values are mapped to Map. *)
 type value =
-  | Bitstr of bitstring  (** Bit strings of fixed size *)
-  | Int of Z.t  (** Integers, unbounded in size, signed *)
-  | Real of Q.t
+  | VBitVec of bitvector  (** Bit strings of fixed size *)
+  | VInt of Z.t  (** Integers, unbounded in size, signed *)
+  | VReal of Q.t
       (** Real number in the mathematical sense, unbounded in size or precision *)
-  | Bool of bool  (** Boolean *)
-  | String of string  (** Strings *)
-  | Map of value map  (** Maps *)
+  | VBool of bool  (** Boolean *)
+  | VString of string  (** Strings *)
+  | VEnum of string  (** Enums *)
+  | VTuple of tuple  (** Tuples **)
+  | VRecord of record  (** Record types *)
+  | VArray of varray  (** Array *)
 
-val find_address_in_value : value -> address -> value Errors.result
-(** Find the value referenced by the address into the value tree. *)
+and record = (string * value) list
+and varray = (Z.t * value) list
+and tuple = value list
 
-val set_address_in_value : value -> address -> value -> value Errors.result
-(** [set_address_in_value obj addr new_value] returns [obj] with [new_value] referenced by [addr]. *)
-
-val value_to_index : value -> index Errors.result
-(** Transform a value into an index, or an [Errors.UnsupportedOperation] if neither an int or a string. *)
-
-val pp_print_index : Format.formatter -> index -> unit
 val pp_print_value : Format.formatter -> value -> unit
-val pp_print_address : Format.formatter -> address -> unit
-val bitstring_of_z : Z.t -> int -> bitstring
-val z_of_bitstring : bitstring -> Z.t
+val bitvector_of_z : Z.t -> int -> bitvector
+val z_of_bitvector : bitvector -> Z.t
 val make_int : int -> value
 val make_real : float -> value
-val make_bitstring : int -> int -> value
-val make_array : value list -> value
+val make_bitvector : int -> int -> value

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -23,3 +23,4 @@ val z_of_bitvector : bitvector -> Z.t
 val make_int : int -> value
 val make_real : float -> value
 val make_bitvector : int -> int -> value
+val find_in_value : value -> value list -> value Errors.result

--- a/test/values.ml
+++ b/test/values.ml
@@ -5,41 +5,32 @@ open Aslinterp__Values
 (********************************************************************************************)
 (** {2 Bitstrings} *)
 
-let zero_bstr = Array.make 8 false
-
-let one_bstr =
-  let r = Array.copy zero_bstr in
-  Array.set r 0 true;
-  r
-
-let two_bstr =
-  let r = Array.copy zero_bstr in
-  Array.set r 1 true;
-  r
+let one_bstr = [ true; false; false; false; false; false; false; false ]
+let two_bstr = [ false; true; false; false; false; false; false; false ]
 
 (** {3 Deconstruction} *)
 
 let test_deconstruct_one () =
   Alcotest.(check int)
     "good deconstruction of 1" 1
-    (Z.to_int (z_of_bitstring one_bstr))
+    (Z.to_int (z_of_bitvector one_bstr))
 
 let test_deconstruct_two () =
   Alcotest.(check int)
     "good deconstruction of 2" 2
-    (Z.to_int (z_of_bitstring two_bstr))
+    (Z.to_int (z_of_bitvector two_bstr))
 
 (** {3 Construction} *)
 
 let test_construct_one () =
-  Alcotest.(check (array bool))
+  Alcotest.(check (list bool))
     "Good construction of 1" one_bstr
-    (bitstring_of_z (Z.of_int 1) 8)
+    (bitvector_of_z (Z.of_int 1) 8)
 
 let test_construct_two () =
-  Alcotest.(check (array bool))
+  Alcotest.(check (list bool))
     "Good construction of 2" two_bstr
-    (bitstring_of_z (Z.of_int 2) 8)
+    (bitvector_of_z (Z.of_int 2) 8)
 
 (********************************************************************************************)
 (** {2 Run tests} *)
@@ -48,12 +39,12 @@ let () =
   let open Alcotest in
   run "Values"
     [
-      ( "bitstring-construction",
+      ( "bitvector-construction",
         [
           test_case "one" `Quick test_construct_one;
           test_case "two" `Quick test_construct_two;
         ] );
-      ( "bitstring-deconstruction",
+      ( "bitvector-deconstruction",
         [
           test_case "one" `Quick test_deconstruct_one;
           test_case "two" `Quick test_deconstruct_two;


### PR DESCRIPTION
The interpreter tries to be as close as possible to ASL syntax, so that post-parser conversion to the interpreted AST is as simple as possible.